### PR TITLE
showing account name

### DIFF
--- a/Sources/Sideproject/Intramodular/Accounts/SideprojectAccountsView.swift
+++ b/Sources/Sideproject/Intramodular/Accounts/SideprojectAccountsView.swift
@@ -120,19 +120,9 @@ extension SideprojectAccountsView {
                         .shadow(color: Color.black.opacity(0.33 / 2), radius: 1)
                 }
                 
-                EditableText(
-                    account.displayName,
-                    text: $account.accountDescription
-                )
-                .onSubmit { text in
-                    if text == "Untitled" {
-                        withoutAnimation(after: .milliseconds(50)) {
-                            account.accountDescription = account.accountTypeDescription.title
-                        }
-                    }
-                }
-                .font(.body.weight(.medium))
-                .foregroundColor(.label)
+                TextView(account.displayName)
+                    .font(.body.weight(.medium))
+                    .foregroundColor(.label)
             }
             .frame(width: .greedy, alignment: .leading)
             .padding(.horizontal, 10)


### PR DESCRIPTION
@vmanot Currently, the SideprojectAccountsView always shows "Untitled" as the account time. There are several problems with using `EditableText`: 

* It is not actually displaying the display name
* It is not clickable / editable since there is a bigger button over the view to allow editing. 

Solution: 
* For now, the quick solution is to just show the display name in a TextView (quick fix below ready to merge)
* In the longer term - I think it makes most sense to let the user edit the name when they add or edit the account along with the API key form. The default display name can already be added to the field and so they can still just enter the API key only or add any identifiers to the account (e.g. OpenAI - work). 